### PR TITLE
Update the calculation of elpd when comparing unimodal vs multimodal models

### DIFF
--- a/src/R/analyzeOpticLobeExpr.R
+++ b/src/R/analyzeOpticLobeExpr.R
@@ -2528,10 +2528,10 @@ inferState <- function(data,
                                                 parameter_name="log_lik_h")
 
                      for (h in 1:length(hList)) {
-                        bim.elpd_i[hList[h]] <- logSumExp(bim.kll[h,]) -
+                        bim.elpd_i[hList[h]] <- logSumExp(bim.kll[ , h]) -
                                                 log(nrow(bim.kll)) ;
 
-                        uni.elpd_i[hList[h]] <- logSumExp(uni.kll[h,]) -
+                        uni.elpd_i[hList[h]] <- logSumExp(uni.kll[ , h]) -
                                                 log(nrow(uni.kll)) ;
                      }
                   }

--- a/test/elpd.R
+++ b/test/elpd.R
@@ -1,0 +1,75 @@
+source("test/environment.R")
+
+# Set up dummy data for InferState()
+set.seed(2022)
+dummy_data <- data.frame(
+  value = c(rnorm(501, mean = 7, sd = 5), rnorm(501, mean = 10, sd = 5)),
+  class = c(rep("A", 501), rep("B", 501)),
+  driver = "driver"
+)
+
+bim.elpd_i <- numeric(length = 1002)
+
+kpart1 <- inferState.partitionK(
+  n = nrow(dummy_data),
+  k = 10,
+  labels = dummy_data$driver
+)
+
+# Only run one iteration as a proof of principle
+for (k in seq(1)) {
+  hList <- which(kpart1 == k)
+  tList <- which(kpart1 != k)
+  
+  # This is modified from line 2401 - 2416 of src/R/analyzeOpticLobeExpr.R
+  stan_bimodal <- list(
+    file        = "test/level1_ordered_CV.stan",
+    # From line 2439 - 2442
+    data        = list(
+      nSamples_t = length(which(kpart1 != k)),
+      nSamples_h = length(which(kpart1 == k)),
+      logE_t     = dummy_data$value[which(kpart1 != k)],
+      logE_h     = dummy_data$value[which(kpart1 == k)]
+    ),
+    iter        = 100, # Just a quick test
+    chains      = 4,
+    cores       = 4,
+    verbose     = FALSE,
+    control     = list(adapt_delta = 0.98)
+  )
+  bimod_fit <- do.call(stan, stan_bimodal)
+  
+  ## Extract elpd: From line 2525 - 2536
+  bim.kll <- extract_log_lik(bimod_fit,
+                             parameter_name="log_lik_h")
+  
+  for (h in 1:length(hList)) {
+    bim.elpd_i[hList[h]] <- logSumExp(bim.kll[h,]) -
+      log(nrow(bim.kll)) ;
+  }
+}
+
+## Structure of log likelihood table
+dim(bim.kll)
+# [1] 200 100
+# Row: 2 * number of iterations
+# Column: Size of a fold that is left-out in each iteration
+
+## Original calculation of elpd
+sum(bim.elpd_i)
+# [1] -361.8318
+
+## Expected value calculated by implementation in the LOO package
+loo::elpd(bim.kll)
+# Estimate   SE
+# elpd   -311.0  9.3
+# ic      622.0 18.6
+
+bim.elpd_i_pr <- numeric(length = 1002)
+# Updated calculation method in PR (take col sum)
+for (h in 1:length(hList)) {
+  bim.elpd_i_pr[hList[h]] <- logSumExp(bim.kll[, h]) -
+    log(nrow(bim.kll)) ;
+}
+sum(bim.elpd_i_pr)
+# [1] -310.9898

--- a/test/environment.R
+++ b/test/environment.R
@@ -1,0 +1,67 @@
+library(rstan)
+library(mclust)
+library(loo)
+library(matrixStats)
+library(txtplot)
+library(caret)
+
+inferState.partitionK <- function(n, k, labels, skipThese) {
+  # Purpose: Partitions a set of points for k-fold cross-validation
+  #
+  # returns: array of k-partition assignment
+  
+  fullList <- 1:n
+  if (!missing(skipThese)) {
+    fullList <- setdiff(fullList, skipThese)
+  } else {
+    skipThese <- c()
+  }
+  
+  kparts <- vector(mode="numeric",length=n)
+  
+  shuffledI <- sample(fullList, length(fullList))
+  medSize <- floor(length(fullList) / k)
+  for (i in 1:k) {
+    t.start <- ((i - 1) * medSize) + 1
+    for (j in t.start:(t.start + medSize - 1)) {
+      kparts[shuffledI[j]] <- i
+    }
+  }
+  
+  if (length(fullList) %% k > 0) {
+    for (j in (k * medSize + 1):length(fullList)) {
+      kparts[shuffledI[j]] <- k
+    }
+  }
+  
+  
+  # If points of a particuilar label are all found in same parition, shuffle with
+  # another class point to reblanace
+  
+  keepLabels <- labels[setdiff(fullList, skipThese)]
+  
+  allGood <- FALSE
+  while (!allGood) {
+    allGood <- TRUE
+    for (curLabel in unique(keepLabels)) {
+      parts <- unique(kparts[labels == curLabel])
+      if (length(parts) == 1) {
+        
+        # swap 2 points: 1 from this label, 2 from another label, in another class.
+        i <- sample(which(labels == curLabel))[1]
+        j <- sample(which(labels != curLabel & kparts != parts[1]))[1]
+        part.t <- kparts[i]
+        kparts[i] <- kparts[j]
+        kparts[j] <- part.t
+        
+        allGood <- FALSE
+      } 
+    }
+  }
+  
+  for (i in skipThese) {
+    kparts[i] <- k + 1 }
+  
+  return(kparts)
+  
+}

--- a/test/level1_ordered_CV.stan
+++ b/test/level1_ordered_CV.stan
@@ -1,0 +1,66 @@
+/*
+ * Models log(O_gs) as mixture of on and off gaussian components
+ *
+ * 1. P(E_g) in bimodal-on v bimodal-off: mix of 2 normals
+ *    1. 'on' nuclei that express gene
+ *    2. 'off' nuclei that do not express gene
+
+ * given GS knowns: O_gs, observed expression matrix (genes x samples)
+ *
+ * infer 5 unknowns:
+ * - P(E_g|on) mu and sigma
+ * - P(E_g|off) mu and sigma
+ * - pi_on mixture weight
+ *
+ */
+
+
+data {
+
+   int<lower=2> nSamples_t ;
+   int<lower=2> nSamples_h ;
+
+   vector [nSamples_t] logE_t;  // observed tx abundance
+   vector [nSamples_h] logE_h;  // observed tx abundance
+
+}
+
+
+parameters {
+
+   positive_ordered[2]        mu ;
+   real<lower=0.001,upper=3>  sd1 ;
+   real<lower=0,upper=1>      pi_on ;    // on/off mixing weight
+
+}
+
+model {
+
+   mu ~ normal(7,5) ;
+
+   for (s in 1:nSamples_t) {
+      target += log_mix(pi_on,
+                        normal_lpdf(logE_t[s] | mu[2], sd1),
+                        normal_lpdf(logE_t[s] | mu[1], sd1));
+   }
+
+}
+
+
+generated quantities {
+
+   vector [nSamples_t] log_lik_t ;
+   vector [nSamples_h] log_lik_h ;
+
+   for (s in 1:nSamples_t) {
+      log_lik_t[s] = log_mix(pi_on,
+                        normal_lpdf(logE_t[s] | mu[2], sd1),
+                        normal_lpdf(logE_t[s] | mu[1], sd1)); }
+
+   for (s in 1:nSamples_h) {
+      log_lik_h[s] = log_mix(pi_on,
+                        normal_lpdf(logE_h[s] | mu[2], sd1),
+                        normal_lpdf(logE_h[s] | mu[1], sd1)); }
+
+
+}


### PR DESCRIPTION
Hi Fred,

Thank you for sharing the mixture modeling code! It's very well-thought and easy to apply not only to the datasets in your study but also other RNA-seq datasets. While I was playing with it, I noticed that the elpd calculation for the model comparison step in the `inferState()` function.

Specifically, since `loo::extract_log_lik()` returns a matrix in which each row is an iteration while each column is a sample within the left-out fold of during cross-validation, the average elpd should be calculated per column.

Please find a minimal reproduction in `test/elpd.R` in this pull request, in which two dummy population were sampled with `rnorm()` and the level1 CV model was fit once to calculate elpd. The calculated elpd and proposed revision are then compared to the result of `loo::elpd()`.

To minimize the change, I edited the assignment code so column sums are calculated in another commit so the patch is separated from the reproduction of the issue I encountered. Please let me know you have any questions!

Best,
Yen